### PR TITLE
Gestor poder emitir certificados de uma atividade individualmente

### DIFF
--- a/app/Http/Controllers/AtividadeController.php
+++ b/app/Http/Controllers/AtividadeController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Request;
 use App\Http\Requests\StoreAtividadeRequest;
 use App\Http\Requests\UpdateAtividadeRequest;
 use App\Validates\AtividadeValidator;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
 
 class AtividadeController extends Controller
@@ -61,6 +62,8 @@ class AtividadeController extends Controller
             return redirect(route('atividade.create', ['acao_id' => $request->acao_id]))->withErrors($exception->validator)->withInput();;
         }
 
+        $acao = Acao::findOrFail($request->acao_id);
+
         if($request->descricao == 'Outra')
         {
             $atividade = new Atividade();
@@ -77,8 +80,15 @@ class AtividadeController extends Controller
             Atividade::create($request->all());
         }
 
+        if(Auth::user()->perfil_id == 3 && $acao->usuario_id != Auth::user()->id)
+        {
+            return redirect(route('gestor.analisar_acao', ['acao_id' => $request->acao_id]))->with(['mensagem' => "Atividade cadastrada com sucesso."]);
+        }
+        else
+        {
+            return redirect(route('atividade.index', ['acao_id' => $request->acao_id]))->with(['mensagem' => "Atividade cadastrada com sucesso."]);
+        }
 
-        return redirect(route('atividade.index', ['acao_id' => $request->acao_id]))->with(['mensagem' => "Atividade cadastrada com sucesso."]);
     }
 
     public function requisicao(Request $request)

--- a/app/Http/Controllers/CertificadoController.php
+++ b/app/Http/Controllers/CertificadoController.php
@@ -94,7 +94,7 @@ class CertificadoController extends Controller
 
             $acao->update();
 
-            Mail::to($acao->participantes())->send(new CertificadoDisponivel([
+            Mail::bcc($acao->participantes())->send(new CertificadoDisponivel([
                 'acao' => $acao->titulo,
             ]));
 
@@ -154,11 +154,14 @@ class CertificadoController extends Controller
 
         $atividade->update();
 
-        /* Mail::to($participantes->email)->send(new CertificadoDisponivel([
-            'acao' => $atividade->acao->titulo,
-        ])); */
+        $participantes_user = $atividade->participantes_user($atividade);
 
-        return redirect(back()->with(['mensagem' => 'Certificados Emitidos!']));
+
+        Mail::bcc($participantes_user)->send(new CertificadoDisponivel([
+            'acao' => $atividade->acao->titulo,
+        ]));
+
+        return redirect(route('atividade.index', ['acao_id' => $atividade->acao_id]))->with(['mensagem' => 'Certificados Emitidos!']);
     }
 
     public function gerar_certificados_requisicao($acao_id)

--- a/app/Models/Atividade.php
+++ b/app/Models/Atividade.php
@@ -45,6 +45,19 @@ class Atividade extends Model
         return $this->hasMany(Participante::class);
     }
 
+    public function participantes_user($atividade){
+        $usuarios = collect();
+
+        $participantes = Participante::where('atividade_id', $atividade->id)->get();
+
+        $participantes->each(function($participante) use ($usuarios)
+        {
+            $usuarios->push($participante->user);
+        });
+
+        return $usuarios;
+    }
+
     public function certificados(){
         return $this->hasMany(Certificado::class);
     }

--- a/database/migrations/2023_12_22_111206_add_column_emissao_parcial_to_atividades_table.php
+++ b/database/migrations/2023_12_22_111206_add_column_emissao_parcial_to_atividades_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('atividades', function (Blueprint $table)
+        {
+            $table->boolean('emissao_parcial')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('atividades', function (Blueprint $table)
+        {
+            $table->dropColumn('emissao_parcial');
+        });
+    }
+};

--- a/resources/views/atividade/atividade_index.blade.php
+++ b/resources/views/atividade/atividade_index.blade.php
@@ -103,6 +103,15 @@
                                     <img src="/images/acoes/listView/lixoIcon.svg" alt="">
                                 </a>
                             @endif
+
+                            @if(Auth::user()->perfil_id == 3 && !$atividade->emissao_parcial && $acao->status != "Aprovada")
+                                <a href="{{ Route('gestor.gerar_certificados_parcial', ['atividade_id' => $atividade->id]) }}"
+                                   onclick="return confirm('Você tem certeza que deseja emitir os certificados desta atividade?')">
+                                    <img src="/images/acoes/listView/submeter.svg" alt="emitir certificados"
+                                         title="Emitir Certificados">
+                                </a>
+                            @endif
+
                         </div>
 
                         <div class="col-4"></div>

--- a/resources/views/gestor_institucional/analisar_acao.blade.php
+++ b/resources/views/gestor_institucional/analisar_acao.blade.php
@@ -21,13 +21,22 @@
                 <div class="text-center mb-3">
                     <h3>Atividades / {{ $acao->titulo }}</h3>
                 </div>
-                <div class="row d-flex align-items-center justify-content-start">
+
+                <div class="row d-flex align-items-center justify-content-between">
                     <div class="col-1">
                         <a type="button" class="button d-flex align-items-center justify-content-around between"
                            href="{{ route('gestor.acoes_submetidas') }}">
                             Voltar
                             <img src="/images/acoes/listView/voltar.svg" alt="">
                         </a>
+                    </div>
+
+                    <div class="col-8 text-end">
+                        @if ($acao->status == 'Em análise')
+                            <a class="criar-acao-button" href="{{ route('atividade.create', ['acao_id' => $acao->id]) }}">
+                                <img class="iconAdd" src="/images/acoes/listView/criar.svg" alt=""> Criar atividade
+                            </a>
+                        @endif
                     </div>
 
                 </div>

--- a/resources/views/participante/list_certificados.blade.php
+++ b/resources/views/participante/list_certificados.blade.php
@@ -1,12 +1,12 @@
 @foreach($participacoes as $participacao)
-    @if($participacao->atividade->acao->status == "Aprovada")
+    @if($participacao->atividade->acao->status == "Aprovada" || $participacao->atividade->emissao_parcial)
         <div class="row linha-table d-flex align-items-center justify-content-start">
             <div class="col-3 titulo-span text-center"><span class="spacing-col">{{$participacao->atividade->acao->titulo}}</span></div>
             <div class="col-2 text-center"><span>{{date( 'd/m/Y' , strtotime($participacao->atividade->data_inicio)).' - '.date( 'd/m/Y' , strtotime($participacao->atividade->data_fim))}}</span></div>
             <div class="col-2 text-center titulo-span"><span>{{$participacao->atividade->descricao}}</span></div>
             <div class="col-2 text-center"><span>{{$participacao->atividade->acao->tipo_natureza->natureza->descricao}}</span></div>
 
-            @if($participacao->atividade->acao->status)
+            @if($participacao->atividade->acao->status == "Aprovada" || $participacao->atividade->emissao_parcial)
                 <div class="col-1 d-flex align-items-end justify-content-end">
                 <span> <a href="{{route('participante.ver_certificado_participante', ['id' => $participacao->id])}}" target="blank">
                             <img src="/images/acoes/listView/certificado.svg" alt="Visualizar" title="Baixar Certificado">

--- a/resources/views/participante/participante_index.blade.php
+++ b/resources/views/participante/participante_index.blade.php
@@ -105,7 +105,7 @@
                                 </a>
                             @endif
 
-                            @if ($acao->status == null || (Auth::user()->perfil_id == 3 && $acao->status != 'Aprovada') || 'Devolvida')
+                            @if($acao->status == null || $acao->status == "Devolvida")
                                 <a href="{{ route('certificado.preview', ['participante_id' => $participante->id]) }}"
                                     target="_blank">
                                     <img src="/images/acoes/listView/certificado.svg" alt=""
@@ -115,11 +115,9 @@
                                 <a href="{{ route('participante.edit', ['participante_id' => $participante->id]) }}">
                                     <img src="/images/acoes/listView/editar.svg" alt="" title="Editar">
                                 </a>
-                            @endif
 
-                            @if ((Auth::user()->perfil_id == 2 || Auth::user()->perfil_id == 3) && $acao->status != 'Aprovada')
                                 <a onclick="return confirm('Você tem certeza que deseja remover o participante?')"
-                                    href="{{ route('participante.delete', ['participante_id' => $participante->id]) }}">
+                                   href="{{ route('participante.delete', ['participante_id' => $participante->id]) }}">
                                     <img src="/images/acoes/listView/lixoIcon.svg" alt="" title="Excluir">
                                 </a>
                             @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -248,6 +248,8 @@ Route::group(['middleware' => ['auth', 'checkGestorInstitucional']], function ()
 
     Route::get('/gestor/gerar_certificados{acao_id}', [CertificadoController::class, 'gerar_certificados'])->name('gestor.gerar_certificados');
 
+    Route::get('/gestor/gerar_certificados/atividade/{atividade_id}', [CertificadoController::class, 'gerar_certificados_parcial'])->name('gestor.gerar_certificados_parcial');
+
     Route::get('/acoes_submetidas_list', [AcaoController::class, 'list_acoes_submetidas'])->name('acoes_submetidas_list');
 
     Route::get('/participante/preview_certificado/{participante_id}', [CertificadoController::class, 'previsualizar_certificado'])->name('certificado.preview');


### PR DESCRIPTION
- Correção nas funções "Pré-visualizar certificado" e "Ver certificado"
- Correção na exibição dos certificados
- Permitir que o gestor crie uma atividade em uma ação enviada para avaliação
- Configuração no envio de e-mails para participantes de atividade em que certificados foram emitidos individualmente